### PR TITLE
Prefer authenticationContext .value over .label

### DIFF
--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Teams-Sharepoint/Invoke-ExecSetSPOSiteAuthContext.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Teams-Sharepoint/Invoke-ExecSetSPOSiteAuthContext.ps1
@@ -15,7 +15,9 @@ function Invoke-ExecSetSPOSiteAuthContext {
     $TenantFilter = $Request.Body.tenantFilter ?? $Request.Query.tenantFilter
     $SiteUrl = $Request.Body.siteUrl ?? $Request.Query.siteUrl
     $ConditionalAccessPolicy = $Request.Body.conditionalAccessPolicy.value ?? $Request.Body.conditionalAccessPolicy ?? $Request.Query.conditionalAccessPolicy
-    $AuthenticationContextName = $Request.Body.authenticationContextName.label ?? $Request.Body.authenticationContextName.value ?? $Request.Body.authenticationContextName ?? $Request.Query.authenticationContextName
+    # Prefer .value (the raw displayName) over .label (the formatted "c1: name" display string).
+    # The autocomplete sends both; the SPO API needs the exact displayName, not the prefixed label.
+    $AuthenticationContextName = $Request.Body.authenticationContextName.value ?? $Request.Body.authenticationContextName.label ?? $Request.Body.authenticationContextName ?? $Request.Query.authenticationContextName
 
     $ValidPolicies = @('AllowFullAccess', 'AllowLimitedAccess', 'BlockAccess', 'AuthenticationContext')
     if (-not $TenantFilter -or -not $SiteUrl -or -not $ConditionalAccessPolicy) {


### PR DESCRIPTION
Change the precedence for extracting authenticationContextName in Invoke-ExecSetSPOSiteAuthContext.ps1 to prefer .value first, then .label, then raw body or query. Autocomplete provides both .value (raw displayName) and .label (prefixed "c1: name"), and the SPO API requires the exact displayName, so prefer .value to avoid sending the formatted label.